### PR TITLE
89 - Minimum kernel versions from SAP note 2812427 need to be moved...

### DIFF
--- a/vars/RedHat_7.yml
+++ b/vars/RedHat_7.yml
@@ -36,4 +36,28 @@ __sap_preconfigure_packages:
   - compat-sap-c++-7
   - compat-sap-c++-9
 
+__sap_preconfigure_min_packages_7_2:
+
+__sap_preconfigure_min_packages_7_3:
+
+# SAP note 2812427:
+__sap_preconfigure_min_packages_7_4:
+  - [ 'kernel' , '3.10.0-693.58.1.el7' ]
+
+# SAP note 2812427:
+__sap_preconfigure_min_packages_7_5:
+  - [ 'kernel' , '3.10.0-862.43.1.el7' ]
+
+# SAP note 2812427:
+__sap_preconfigure_min_packages_7_6:
+  - [ 'kernel' , '3.10.0-957.35.1.el7' ]
+
+__sap_preconfigure_min_packages_7_7:
+
+__sap_preconfigure_min_packages_7_8:
+
+__sap_preconfigure_min_packages_7_9:
+
+__sap_preconfigure_min_pkgs: "{{ lookup('vars','__sap_preconfigure_min_packages_' + ansible_distribution_version|string|replace (\".\", \"_\")) }}"
+
 ...

--- a/vars/RedHat_8.0.yml
+++ b/vars/RedHat_8.0.yml
@@ -24,7 +24,9 @@ __sap_preconfigure_packages:
   - nfs-utils
   - bind-utils
 
+# SAP notes 2772999 (setup) and 2812427 (kernel):
 __sap_preconfigure_min_pkgs:
   - [ 'setup' , '2.12.2-2.el8_0.1' ]
+  - [ 'kernel' , '4.18.0-80.15.1.el8_0' ]
 
 ...


### PR DESCRIPTION
… from sap-hana-preconfigure to sap-preconfigure. SAP note 2812427 is not specific to SAP HANA but applies to SAP HANA and SAP NetWeaver.