### PR TITLE
Prepare role for archiving

### DIFF
--- a/DISCONTINUATION_NOTICE.md
+++ b/DISCONTINUATION_NOTICE.md
@@ -1,5 +1,5 @@
 Note: Development and maintenance of this software has stopped.
 
 Its functional scope is covered and expanded by role [sap_general_preconfigure](https://github.com/sap-linuxlab/community.sap_install/tree/main/roles/sap_general_preconfigure).
-The role is part of Ansible Collection [sap_install](https://github.com/sap-linuxlab/community.sap_install) and transferred to the
-GitHub organization [sap-linuxlab](https://github.com/sap-linuxlab) as a joint initiative by SAP Technology Partners.
+The role is part of Ansible Collection [sap_install](https://github.com/sap-linuxlab/community.sap_install) in the
+GitHub organization [sap-linuxlab](https://github.com/sap-linuxlab), which is a joint initiative by SAP Technology Partners.

--- a/DISCONTINUATION_NOTICE.md
+++ b/DISCONTINUATION_NOTICE.md
@@ -1,0 +1,5 @@
+Note: Development and maintenance of this software has stopped.
+
+Its functional scope is covered and expanded by role [sap_general_preconfigure](https://github.com/sap-linuxlab/community.sap_install/tree/main/roles/sap_general_preconfigure).
+The role is part of Ansible Collection [sap_install](https://github.com/sap-linuxlab/community.sap_install) and transferred to the
+GitHub organization [sap-linuxlab](https://github.com/sap-linuxlab) as a joint initiative by SAP Technology Partners.

--- a/README.md
+++ b/README.md
@@ -1,4 +1,6 @@
 # **NOTE:** Development and maintenance of this software has stopped.
+The successor role is [sap_general_preconfigure](https://github.com/sap-linuxlab/community.sap_install/tree/main/roles/sap_general_preconfigure).
+
 For more information, see [DISCONTINUATION_NOTICE.md](DISCONTINUATION_NOTICE.md).
 ***
 

--- a/README.md
+++ b/README.md
@@ -1,3 +1,7 @@
+# **NOTE:** Development and maintenance of this software has stopped.
+For more information, see [DISCONTINUATION_NOTICE.md](DISCONTINUATION_NOTICE.md).
+***
+
 sap-preconfigure
 ================
 

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -4,6 +4,17 @@
   debug:
     var: role_path
 
+- name: Print deprecation notice
+  pause:
+    prompt: |
+      ""
+      "*** NOTE: This role is deprecated. ***"
+      ""
+      "Role sap_general_preconfigure provides all the features of this role, and more."
+      "You can find the role in repository https://www.github.com/sap-linuxlab/community.sap_install ."
+      ""
+      "Press RETURN to continue anyway, or <ctrl>c, a, to abort:"
+
 - name: Include OS specific vars
   include_vars: '{{ item }}'
   with_first_found:


### PR DESCRIPTION
We want to discontinue development and maintenance of this role.

Its functional scope is covered and expanded by role [sap_general_preconfigure](https://github.com/sap-linuxlab/community.sap_install/tree/main/roles/sap_general_preconfigure). The role is part of Ansible Collection [sap_install](https://github.com/sap-linuxlab/community.sap_install) in the GitHub organization [sap-linuxlab](https://github.com/sap-linuxlab), which is a joint initiative by SAP Technology Partners.

Note: I have copied all open issues to https://github.com/sap-linuxlab/community.sap_install/issues .